### PR TITLE
Fix AI service network errors in production GitLab deployments

### DIFF
--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -5,11 +5,12 @@ import logger from '../utils/logger';
 const getApiUrl = () => {
   const hostname = window.location.hostname;
   if (hostname === 'localhost' || hostname === '127.0.0.1') {
-    // Use proxy when accessing via localhost
+    // Use proxy when accessing via localhost in development
     return '/api/ai';
   } else {
-    // Use direct backend URL when accessing via external IP
-    return `http://${hostname}:3001/api/ai`;
+    // In production, frontend and backend run in same container
+    // Use relative URL to avoid protocol/port issues
+    return '/api/ai';
   }
 };
 


### PR DESCRIPTION
## Summary
- Fixes AI service network errors causing "Load failed" when creating tasks in GitLab production deployments
- Resolves TypeError network errors by using relative URLs instead of hardcoded protocol/port assumptions
- Ensures compatibility with single-container production architecture where frontend and backend run together

## Problem Analysis
The AI service was failing in production because:

1. **Protocol Mismatch**: Hardcoded `http://` URLs on HTTPS GitLab deployments caused mixed content errors
2. **Port Assumption**: Assumed backend runs on port 3001, but Cloud Run uses dynamic ports (typically 8080)
3. **Architecture Misalignment**: Created unnecessary cross-origin requests when both frontend and backend run in the same container

## Technical Changes
**File**: `src/services/aiService.ts`
- Changed production URL construction from `http://${hostname}:3001/api/ai` to `/api/ai`
- Updated comments to clarify single-container production architecture
- Maintains backward compatibility with development proxy setup

## Test plan
- [x] Verify development environment still works with proxy
- [ ] Deploy to production and test task creation
- [ ] Confirm AI service connectivity in GitLab environment
- [ ] Validate no console errors during task generation

## Root Cause
Production deployments serve both React frontend and Express backend from the same container/origin. The relative URL `/api/ai` works correctly in both:
- **Development**: React dev server proxy forwards to localhost:3001
- **Production**: Express serves static files AND handles /api/* routes on same origin

🤖 Generated with [Claude Code](https://claude.ai/code)