### PR TITLE
fix: Resolve Cloud Run deployment failure with server startup condition

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,7 @@ COPY --from=frontend-builder --chown=nextjs:nodejs /app/build ./build
 COPY --chown=nextjs:nodejs server/server.js ./server/
 COPY --chown=nextjs:nodejs server/gitlabService.js ./server/
 COPY --chown=nextjs:nodejs server/logger.js ./server/
+COPY --chown=nextjs:nodejs server/utils/ ./server/utils/
 
 # Re-declare build args for runtime stage
 ARG GIT_SHA

--- a/server/server.js
+++ b/server/server.js
@@ -1138,7 +1138,9 @@ app.use((req, res) => {
 export default app;
 
 // Only start the server if this file is run directly
-if (import.meta.url === `file://${process.argv[1]}`) {
+// Use path.resolve to handle both relative and absolute paths correctly
+import { pathToFileURL } from 'url';
+if (import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
   app.listen(port, '0.0.0.0', () => {
     logger.startup(`✅ Server successfully listening at http://0.0.0.0:${port}`);
     logger.startup(`🌐 Health check available at http://0.0.0.0:${port}/health`);


### PR DESCRIPTION
## 🚨 Hotfix: Cloud Run Deployment Failure

This PR fixes a critical bug introduced in v1.8.1 that prevents the application from starting in Cloud Run production environments.

## 🐛 Problem
**Cloud Run deployment fails with:**
```
The user-provided container failed to start and listen on the port defined provided by the PORT=8080 environment variable
```

## 🔍 Root Cause Analysis
The issue is in the server startup condition in `server/server.js`:

**Original problematic code:**
```javascript
if (import.meta.url === `file://${process.argv[1]}`) {
  app.listen(port, '0.0.0.0', () => { ... });
}
```

**Problem:** In containerized environments (Cloud Run), the path resolution between `import.meta.url` and `process.argv[1]` is inconsistent:
- `import.meta.url` provides absolute file URL
- `process.argv[1]` might be relative path
- Comparison fails → server never calls `app.listen()` → health check fails

## 🔧 Solution
**Fixed code:**
```javascript
import { pathToFileURL } from 'url';
if (import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
  app.listen(port, '0.0.0.0', () => { ... });
}
```

**Benefits:**
- Uses `pathToFileURL(path.resolve())` for robust path comparison
- Handles both absolute and relative paths correctly
- Works consistently across development and production environments
- Maintains existing functionality

## 🧪 Testing
- ✅ **Local development**: Server starts correctly on port 3001
- ✅ **Health check**: Responds properly at `/health`
- ✅ **No regressions**: Existing functionality preserved
- 🔄 **Cloud Run**: Ready for deployment testing

## 📊 Impact
- **Severity**: Critical (P1) - Blocks all production deployments
- **Affected versions**: v1.8.1
- **Target**: Hotfix for immediate deployment

## 🔗 Related
- Fixes deployment failure reported in v1.8.1
- Enables successful Cloud Run deployment with proper port binding
- Resolves container startup timeout issues

## Test Plan
- [x] Verify local development server starts
- [x] Confirm health check endpoint works
- [ ] Deploy to Cloud Run and verify successful startup
- [ ] Confirm application functionality in production

**Ready for Cloud Run deployment testing\!**